### PR TITLE
使备份表支持innodb 表压缩

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ port=6669
 socket=/tmp/inc.socket
 character-set-client-handshake=0
 character-set-server=utf8
+inception_language_code=zh-CN
 inception_remote_system_password=root
 inception_remote_system_user=wzf1
 inception_remote_backup_port=3306

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -8000,7 +8000,7 @@ int mysql_get_create_sql_backup_table(
     create_sql->append("type VARCHAR(20),");
     create_sql->append("PRIMARY KEY(opid_time)");
 
-    create_sql->append(")ENGINE INNODB DEFAULT CHARSET UTF8MB4;");
+    create_sql->append(")ENGINE INNODB DEFAULT CHARSET UTF8MB4 ROW_FORMAT compressed;");
 
     return 0;
 }
@@ -8023,7 +8023,7 @@ int mysql_get_create_sql_from_table_info(
     create_sql->append("rollback_statement longtext, ");
     create_sql->append("opid_time varchar(50), ");
     create_sql->append("KEY idx_opid_time (opid_time)");
-    create_sql->append(") ENGINE INNODB DEFAULT CHARSET UTF8MB4;");
+    create_sql->append(") ENGINE INNODB DEFAULT CHARSET UTF8MB4 ROW_FORMAT compressed;");
 
     return 0;
 }
@@ -8096,7 +8096,7 @@ int mysql_get_statistic_table_sql(
     create_sql->append("createdb int not null default 0, ");
     create_sql->append("truncating int not null default 0 ");
 
-    create_sql->append(") ENGINE INNODB DEFAULT CHARSET UTF8;");
+    create_sql->append(") ENGINE INNODB DEFAULT CHARSET UTF8 ROW_FORMAT compressed;");
 
     return 0;
 }


### PR DESCRIPTION
1 mysql备份数据库 调整配置参数开启压缩功能
`my.cnf中增加
innodb_file_format                                                      = Barracuda
innodb_file_format_max                                              = Barracuda`
`mysql中执行
set global innodb_file_format="Barracuda"; 
set global innodb_file_format_max="Barracuda";
`
ps 如不做上述操作 也可使用，只有在做 tablespace import时会出现导入失败问题
2 如已存在相关的备份表 需要手动修改为压缩表
`alter table table1 ROW_FORMAT=COMPRESSED;`
3 新增备份表将自动建立为压缩表
